### PR TITLE
Fix homebrew install URL

### DIFF
--- a/code/octave.markdown
+++ b/code/octave.markdown
@@ -17,7 +17,7 @@ Next, open up a Terminal and do the following:
 
 {% highlight bash %}
 # install Homebrew http://brew.sh/ if you don't already have it 
-ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)" 
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" 
 
 # tap the science formulae
 brew tap homebrew/science


### PR DESCRIPTION
The new URL is from the Homebrew site at brew.sh. The old URL gives a 400 error.