### PR TITLE
Update octave.markdown

### DIFF
--- a/code/octave.markdown
+++ b/code/octave.markdown
@@ -44,6 +44,9 @@ brew install fltk
 brew install gnuplot --with-x11
 {% endhighlight %}
 
+# you might need to install legacy Java 6 runtime
+https://support.apple.com/kb/DL1572?locale=en_US
+
 Last, you need to edit your .octaverc file to get gnuplot to play nicely with Octave. So, in your home directory, create a new .octaverc file and paste the following:
 
 {% highlight bash %}


### PR DESCRIPTION
The legacy Java 6 runtime is required to open octave
